### PR TITLE
adding replication keys to streams and valid-replication-key metadata

### DIFF
--- a/tap_bronto/endpoints/contact.py
+++ b/tap_bronto/endpoints/contact.py
@@ -17,8 +17,9 @@ LOGGER = singer.get_logger()  # noqa
 class ContactStream(Stream):
 
     TABLE = 'contact'
+    REPLICATION_KEY = 'modified'
     KEY_PROPERTIES = ['id']
-    SCHEMA, METADATA = with_properties(CONTACT_SCHEMA, KEY_PROPERTIES)
+    SCHEMA, METADATA = with_properties(CONTACT_SCHEMA, KEY_PROPERTIES, [REPLICATION_KEY])
 
     def make_filter(self, start, end):
         start_filter = self.client.factory.create('dateValue')
@@ -152,7 +153,7 @@ class ContactStream(Stream):
                     hasMore = False
 
             self.state = incorporate(
-                self.state, table, 'modified',
+                self.state, table, self.REPLICATION_KEY,
                 start.replace(microsecond=0).isoformat())
 
             save_state(self.state)

--- a/tap_bronto/endpoints/inbound_activity.py
+++ b/tap_bronto/endpoints/inbound_activity.py
@@ -17,8 +17,9 @@ LOGGER = singer.get_logger()  # noqa
 class InboundActivityStream(Stream):
 
     TABLE = 'inbound_activity'
+    REPLICATION_KEY = 'createdDate'
     KEY_PROPERTIES = ['id']
-    SCHEMA, METADATA = with_properties(ACTIVITY_SCHEMA, KEY_PROPERTIES)
+    SCHEMA, METADATA = with_properties(ACTIVITY_SCHEMA, KEY_PROPERTIES, [REPLICATION_KEY])
 
     def make_filter(self, start, end):
         _filter = self.client.factory.create(
@@ -110,7 +111,7 @@ class InboundActivityStream(Stream):
                     hasMore = False
 
             self.state = incorporate(
-                self.state, table, 'createdDate',
+                self.state, table, self.REPLICATION_KEY,
                 start.replace(microsecond=0).isoformat())
 
             save_state(self.state)

--- a/tap_bronto/endpoints/list.py
+++ b/tap_bronto/endpoints/list.py
@@ -35,7 +35,7 @@ class ListStream(Stream):
             'description': ('The status of the list. Valid values '
                             'are active, deleted, and tmp')
         }
-    }, KEY_PROPERTIES)
+    }, KEY_PROPERTIES, [])
 
     def sync(self):
         key_properties = self.catalog.get('key_properties')

--- a/tap_bronto/endpoints/outbound_activity.py
+++ b/tap_bronto/endpoints/outbound_activity.py
@@ -18,8 +18,9 @@ LOGGER = singer.get_logger()  # noqa
 class OutboundActivityStream(Stream):
 
     TABLE = 'outbound_activity'
+    REPLICATION_KEY = 'createdDate'
     KEY_PROPERTIES = ['id']
-    SCHEMA, METADATA = with_properties(ACTIVITY_SCHEMA, KEY_PROPERTIES)
+    SCHEMA, METADATA = with_properties(ACTIVITY_SCHEMA, KEY_PROPERTIES, [REPLICATION_KEY])
 
     def make_filter(self, start, end):
         _filter = self.client.factory.create(
@@ -111,7 +112,7 @@ class OutboundActivityStream(Stream):
                     hasMore = False
 
             self.state = incorporate(
-                self.state, table, 'createdDate',
+                self.state, table, self.REPLICATION_KEY,
                 start.replace(microsecond=0).isoformat())
 
             save_state(self.state)

--- a/tap_bronto/endpoints/unsubscribe.py
+++ b/tap_bronto/endpoints/unsubscribe.py
@@ -14,6 +14,7 @@ LOGGER = singer.get_logger()  # noqa
 class UnsubscribeStream(Stream):
 
     TABLE = 'unsubscribe'
+    REPLICATION_KEY = 'created'
     KEY_PROPERTIES = ['contactId', 'method', 'created']
     SCHEMA, METADATA = with_properties({
         'contactId': {
@@ -43,7 +44,7 @@ class UnsubscribeStream(Stream):
             'type': ['string'],
             'description': 'The date/time the unsubscribe was created.'
         }
-    }, KEY_PROPERTIES)
+    }, KEY_PROPERTIES, [REPLICATION_KEY])
 
     def make_filter(self, start, end):
         _filter = self.client.factory.create('unsubscribeFilter')
@@ -100,7 +101,7 @@ class UnsubscribeStream(Stream):
                 self.state = incorporate(
                     self.state,
                     table,
-                    'start_date',
+                    self.REPLICATION_KEY,
                     start.isoformat())
 
                 save_state(self.state)

--- a/tap_bronto/schemas.py
+++ b/tap_bronto/schemas.py
@@ -3,7 +3,7 @@ from funcy import project
 from datetime import datetime
 from singer import metadata
 
-def with_properties(properties, key_properties):
+def with_properties(properties, key_properties, valid_replication_keys):
     return_schema = {
         'type': 'object',
         'properties': properties,
@@ -20,6 +20,7 @@ def with_properties(properties, key_properties):
 
     # TODO: Add more here?
     mdata = metadata.write(mdata, (), 'table-key-properties', key_properties)
+    mdata = metadata.write(mdata, (), 'valid-replication-keys', valid_replication_keys)
 
     return return_schema, metadata.to_list(mdata)
 

--- a/tap_bronto/stream.py
+++ b/tap_bronto/stream.py
@@ -16,6 +16,7 @@ class Stream:
     TABLE = None
     KEY_PROPERTIES = []
     SCHEMA = {}
+    REPLICATION_KEY = None
 
     def __init__(self, config={}, state={}, catalog=[]):
         self.client = None


### PR DESCRIPTION
The activities and contact streams were not showing incremental replication as an option.  This adds the replication key to each stream that has one, and writes them as `valid-replication-keys` metadata during discovery.  

Now when these streams are selected in the UI, incremental replication is assumed, although clicking on `table settings` allows users to switch to full-table.

The `List` stream does not support incremental replication since there is no useful way to filter the results from the endpoint.  When this stream is selected in the UI, incremental replication is greyed out and full-table is the only option.