### PR TITLE
Use metadata to determine replication-method in sync mode

### DIFF
--- a/tap_bronto/stream.py
+++ b/tap_bronto/stream.py
@@ -2,6 +2,7 @@ import singer
 import suds
 import sys
 
+from singer import metadata
 from tap_bronto.state import get_last_record_value_for_table
 from dateutil import parser
 
@@ -33,8 +34,8 @@ class Stream:
 
         start = get_last_record_value_for_table(self.state, table)
 
-        replication_method = self.catalog.get('replication_method',
-                                              'INCREMENTAL')
+        mdata = metadata.to_map(self.catalog.get('metadata', {}))
+        replication_method = metadata.get(mdata, (), 'replication-method') or 'INCREMENTAL'
 
         if replication_method == 'FULL_TABLE':
             LOGGER.info('Using FULL_TABLE replication. (All data since {})'


### PR DESCRIPTION
This PR addresses an issue where the replication method is not discovered properly, resulting in this error:

```
2018-04-26 13:15:05,067Z    tap - ERROR Unknown replication method None!
2018-04-26 13:15:05,067Z    tap - ERROR Failed to sync endpoint, moving on!
```

This appears to have been an oversight in the metadata conversion of `selected`, `selected-by-default`, etc... The tap will now use metadata to find the replication method, as is the current standard.